### PR TITLE
Fix/antlr ambiguous import

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/caibirdme/yql
 go 1.15
 
 require (
-	github.com/antlr/antlr4 v0.0.0-20210121092344-5dce78c87a9e
+	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210716071054-a231a1a7f1cc
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,13 @@
-github.com/antlr/antlr4 v0.0.0-20210121092344-5dce78c87a9e h1:1YJFJAhOCHWLME6YEBM0BI96x4P5mKEl6i6pdgg36WI=
-github.com/antlr/antlr4 v0.0.0-20210121092344-5dce78c87a9e/go.mod h1:T7PbCXFs94rrTttyxjbyT5+/1V8T2TYDejxUfHJjw1Y=
+github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210716071054-a231a1a7f1cc h1:0LxTNJTbCStbOMoNcQEc6naaWfU7rI0b+Zdns1EI7TA=
+github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210716071054-a231a1a7f1cc/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Fix antlr ambiguous import issue
```sh
go get -u github.com/antlr/antlr4/runtime/Go/antlr
go: downloading github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220209000751-70bdcdff7ee1
go: downloading github.com/antlr/antlr4 v0.0.0-20220209000751-70bdcdff7ee1
github.com/antlr/antlr4/runtime/Go/antlr: ambiguous import: found package github.com/antlr/antlr4/runtime/Go/antlr in multiple modules:
	github.com/antlr/antlr4 v0.0.0-20210121092344-5dce78c87a9e (~/go/pkg/mod/github.com/antlr/antlr4@v0.0.0-20210121092344-5dce78c87a9e/runtime/Go/antlr)
	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220209000751-70bdcdff7ee1 (~/go/pkg/mod/github.com/antlr/antlr4/runtime/!go/antlr@v0.0.0-20220209000751-70bdcdff7ee1)
```